### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Tutorials:
 
 Implementations in other languages:
 
-  - [php](http://github.com/everzet/jade.php)
+  - [php](https://github.com/kylekatarnls/jade-php)
   - [scala](http://scalate.fusesource.org/versions/snapshot/documentation/scaml-reference.html)
   - [ruby](https://github.com/slim-template/slim)
   - [python](https://github.com/SyrusAkbary/pyjade)


### PR DESCRIPTION
# Updated the PHP implementation link.
- everzet/jade.php repository has been abandoned, supposedly.
- kylekatarnls/jade-php is on packagist and has a larger usage than everzet/jade
- everzet/jade on packagist leads to Laravel vendor package.