### PR TITLE
Class literal is duplicating the bing class

### DIFF
--- a/docs/views/reference/attributes.jade
+++ b/docs/views/reference/attributes.jade
@@ -172,11 +172,11 @@ block documentation
           - var classes = ['foo', 'bar', 'baz']
           a(class=classes)
           //- the class attribute may also be repeated to merge arrays
-          a(class=classes class=['bing'])
+          a.bang(class=classes class=['bing'])
     .col-lg-6
       +html
         :htmlsrc
-          <a class="foo bar baz"></a><a class="foo bar baz bing"></a>
+          <a class="foo bar baz"></a><a class="bang foo bar baz bing"></a>
 
   p It can also be an object mapping class names to true or false values, which is useful for applying conditional classes
 

--- a/docs/views/reference/attributes.jade
+++ b/docs/views/reference/attributes.jade
@@ -172,7 +172,7 @@ block documentation
           - var classes = ['foo', 'bar', 'baz']
           a(class=classes)
           //- the class attribute may also be repeated to merge arrays
-          a.bing(class=classes class=['bing'])
+          a(class=classes class=['bing'])
     .col-lg-6
       +html
         :htmlsrc


### PR DESCRIPTION
In the **Class Attributes** part of the Language Reference, the anchor tag has a **Class Literal** attached. This, in addition to the second class attribute is making it so the element has **bing** as a class twice. Judging by the docs source, this is not the intended outcome as it shows only one **bing** class.

The `/docs` source shows the following:
```html
:htmlsrc
  <a class="foo bar baz"></a><a class="foo bar baz bing"></a>
```

The generated html on the live site:
```html
<a class="foo bar baz"></a><a class="bing foo bar baz bing"></a>
```

**Note:** I wasn't able to get the CodeMirror working when following the contribution instructions found on #1927 so the html source wasn't being generated from the jade source which meant the html source was showing the hard coded value which was the desired result. If the code was to be generated from the jade source, it would have the second **bing** class from the Literal.