### PR TITLE
meta: update repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jadejs/jade"
+    "url": "git://github.com/pugjs/jade"
   },
   "main": "lib",
   "bin": {


### PR DESCRIPTION
currently the package.json still refers to the jadejs org

This patch replaces it with the pugjs org