### PR TITLE
Change repo links to pugjs/jade

### DIFF
--- a/docs/views/layout.jade
+++ b/docs/views/layout.jade
@@ -35,8 +35,8 @@ html
                 li(class=section === 'history' ? 'active' : false)
                   a(href='/history') Change Log
                 li: a(href='https://coveralls.io/r/jadejs/jade?branch=master') Code Coverage
-                li: a(href='https://travis-ci.org/jadejs/jade') Test Results
-                li: a(href='https://github.com/jadejs/jade') GitHub Repository
+                li: a(href='https://travis-ci.org/pugjs/jade') Test Results
+                li: a(href='https://github.com/pugjs/jade') GitHub Repository
               block navigation
         .container
           block content
@@ -48,7 +48,7 @@ html
             | Jade is a template language maintained by&nbsp;
             a(href='http://www.forbeslindesay.co.uk') @ForbesLindesay
             | &nbsp;and contributed by&nbsp;
-            a(href='https://github.com/jadejs/jade/graphs/contributors') many others
+            a(href='https://github.com/pugjs/jade/graphs/contributors') many others
             |.
     include ./includes/ga.jade
     script(src=path("/client.js"))


### PR DESCRIPTION
Right now jadejs/jade is a different person's repository (squatter maybe?). I changed Travis to pugjs as well, but coveralls gives me a 404 at pugjs/jade.